### PR TITLE
✨ feat(welcome): 添加登录状态检查，未登录用户点击 Enter 跳转到登录页面

### DIFF
--- a/src/app/[variants]/(main)/welcome/index.tsx
+++ b/src/app/[variants]/(main)/welcome/index.tsx
@@ -4,10 +4,12 @@ import { Button } from 'antd';
 import { createStyles } from 'antd-style';
 import { ChevronRight } from 'lucide-react';
 import { memo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Center, Flexbox } from 'react-layout-kit';
+import { useNavigate } from 'react-router-dom';
 
 import { ProductLogo } from '@/components/Branding';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 const useStyles = createStyles(({ css, token }) => ({
   container: css`
@@ -101,9 +103,15 @@ const useStyles = createStyles(({ css, token }) => ({
 const WelcomePage = memo(() => {
   const { styles } = useStyles();
   const navigate = useNavigate();
+  const isLogin = useUserStore((s) => authSelectors.isLogin(s));
+  const openLogin = useUserStore((s) => s.openLogin);
 
   const handleEnter = () => {
-    navigate('/chat');
+    if (isLogin) {
+      navigate('/chat');
+    } else {
+      openLogin();
+    }
   };
 
   return (

--- a/src/app/market-auth-callback/page.tsx
+++ b/src/app/market-auth-callback/page.tsx
@@ -121,7 +121,7 @@ const MarketAuthCallbackPage = () => {
     }
   };
 
-  const getTitle = () => {
+  const getTitle = (): string => {
     switch (status) {
       case 'loading': {
         return t('callback.titles.loading');

--- a/src/locales/default/marketAuth.ts
+++ b/src/locales/default/marketAuth.ts
@@ -21,12 +21,11 @@ export default {
       successWithCountdown: '{{message}} 窗口将在 {{countdown}} 秒后自动关闭',
       successWithRedirect: '授权成功！正在跳转...',
     },
-  },
-  result: {
-    authorized: 'ProtoChat 服务授权成功',
-    desc: '即将跳转到 ProtoChat Market...',
-    error: '授权失败',
-    errorDesc: '请重试或联系支持',
+    titles: {
+      error: '授权失败',
+      loading: '正在处理',
+      success: '授权成功',
+    },
   },
   errors: {
     authorizationFailed: '授权失败，请重试。',
@@ -52,5 +51,11 @@ export default {
       submit: '授权成功！现在可以发布助手了。',
       upload: '授权成功！现在可以发布新版本了。',
     },
+  },
+  result: {
+    authorized: 'ProtoChat 服务授权成功',
+    desc: '即将跳转到 ProtoChat Market...',
+    error: '授权失败',
+    errorDesc: '请重试或联系支持',
   },
 };


### PR DESCRIPTION
## Summary
- 在欢迎页面（/welcome）添加登录状态检查
- 未登录用户点击 Enter 按钮时跳转到登录页面，而不是直接进入 /chat
- 已登录用户点击 Enter 按钮正常跳转到 /chat

## 额外修复
- 修复 market-auth-callback 页面的类型错误：添加缺失的 `callback.titles` 翻译 key
- 修复 `getTitle` 函数返回类型

## Test plan
- [ ] 未登录状态访问 /welcome，点击 Enter 应跳转到登录页面
- [ ] 已登录状态访问 /welcome，点击 Enter 应跳转到 /chat
- [ ] 类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)