### PR TITLE
✨ feat(chat): 添加登录状态检查，未登录用户跳转到登录页面

### DIFF
--- a/src/app/[variants]/(main)/chat/_layout/Desktop/index.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Desktop/index.tsx
@@ -1,14 +1,41 @@
+import { useEffect } from 'react';
 import { Flexbox } from 'react-layout-kit';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
+import { enableAuth } from '@/const/auth';
 import { isDesktop } from '@/const/version';
 import ProtocolUrlHandler from '@/features/ProtocolUrlHandler';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 
 import RegisterHotkeys from './RegisterHotkeys';
 import SessionPanel from './SessionPanel';
 import Workspace from './Workspace';
 
 const Layout = () => {
+  const navigate = useNavigate();
+  const [isLogin, isLoaded] = useUserStore((s) => [
+    authSelectors.isLogin(s),
+    authSelectors.isLoaded(s),
+  ]);
+
+  // Redirect to signin page if not logged in
+  useEffect(() => {
+    // Wait for auth state to be loaded
+    if (!isLoaded) return;
+
+    // Redirect to signin if auth is enabled and user is not logged in
+    if (enableAuth && !isLogin) {
+      const currentUrl = window.location.href;
+      window.location.href = `/signin?callbackUrl=${encodeURIComponent(currentUrl)}`;
+    }
+  }, [isLoaded, isLogin, navigate]);
+
+  // Don't render content while checking auth or if not logged in
+  if (enableAuth && (!isLoaded || !isLogin)) {
+    return null;
+  }
+
   return (
     <>
       <Flexbox

--- a/src/app/[variants]/(main)/chat/_layout/Mobile.tsx
+++ b/src/app/[variants]/(main)/chat/_layout/Mobile.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { createStyles } from 'antd-style';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { Flexbox } from 'react-layout-kit';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import { withSuspense } from '@/components/withSuspense';
+import { enableAuth } from '@/const/auth';
 import { useShowMobileWorkspace } from '@/hooks/useShowMobileWorkspace';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 
 import SessionPanelContent from '../components/SessionPanel';
-import { Outlet } from 'react-router-dom';
 
 const useStyles = createStyles(({ css, token }) => ({
   main: css`
@@ -18,9 +21,31 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-const Layout = memo(( ) => {
+const Layout = memo(() => {
   const showMobileWorkspace = useShowMobileWorkspace();
   const { styles } = useStyles();
+  const navigate = useNavigate();
+  const [isLogin, isLoaded] = useUserStore((s) => [
+    authSelectors.isLogin(s),
+    authSelectors.isLoaded(s),
+  ]);
+
+  // Redirect to signin page if not logged in
+  useEffect(() => {
+    // Wait for auth state to be loaded
+    if (!isLoaded) return;
+
+    // Redirect to signin if auth is enabled and user is not logged in
+    if (enableAuth && !isLogin) {
+      const currentUrl = window.location.href;
+      window.location.href = `/signin?callbackUrl=${encodeURIComponent(currentUrl)}`;
+    }
+  }, [isLoaded, isLogin, navigate]);
+
+  // Don't render content while checking auth or if not logged in
+  if (enableAuth && (!isLoaded || !isLogin)) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- 在 /chat 页面添加登录状态检查
- 未登录用户访问 /chat 时自动跳转到登录页面
- 登录后通过 callbackUrl 返回原页面

## 修改内容
- `src/app/[variants]/(main)/chat/_layout/Desktop/index.tsx` - Desktop 版本添加认证检查
- `src/app/[variants]/(main)/chat/_layout/Mobile.tsx` - Mobile 版本添加认证检查

## 实现逻辑
1. 等待认证状态加载完成 (`isLoaded`)
2. 检查用户是否登录 (`isLogin`)
3. 如果启用了认证 (`enableAuth`) 且用户未登录，跳转到 `/signin?callbackUrl=...`
4. 在认证检查期间不渲染页面内容

## Test plan
- [ ] 未登录状态访问 /chat，应跳转到登录页面
- [ ] 已登录状态访问 /chat，应正常显示聊天界面
- [ ] 登录后应返回原 /chat 页面

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)