### PR TITLE
✨ feat(auth): 用户注册时自动分配默认头像

### DIFF
--- a/src/app/(backend)/api/auth/casdoor/login/route.ts
+++ b/src/app/(backend)/api/auth/casdoor/login/route.ts
@@ -10,6 +10,7 @@ import { CasdoorClient } from '@/server/modules/Casdoor';
 import { createSignedSessionCookie } from '@/server/modules/Casdoor/cookie';
 import type { CasdoorLoginRequest, CasdoorLoginResponse } from '@/server/modules/Casdoor/types';
 import { UserService } from '@/server/services/user';
+import { generateDefaultAvatar, isValidAvatar } from '@/server/utils/avatar';
 
 // Session configuration
 const SESSION_EXPIRES_IN_DAYS = 7;
@@ -189,8 +190,13 @@ export async function POST(req: NextRequest) {
     if (!existingUser) {
       // Create new user
       const userId = idGenerator('user', 32 - 'user_'.length);
+
+      // Use Casdoor avatar if available, otherwise generate a default one
+      const casdoorAvatar = userInfo.avatar || userInfo.permanentAvatar;
+      const avatar = isValidAvatar(casdoorAvatar) ? casdoorAvatar : generateDefaultAvatar(userId);
+
       await serverDB.insert(users).values({
-        avatar: userInfo.avatar || userInfo.permanentAvatar,
+        avatar,
         createdAt: now,
         email,
         emailVerified: userInfo.email_verified ?? false,
@@ -210,11 +216,12 @@ export async function POST(req: NextRequest) {
 
       existingUser = { id: userId };
     } else {
-      // Update existing user info
+      // Update existing user info (only update avatar if Casdoor provides one)
+      const casdoorAvatar = userInfo.avatar || userInfo.permanentAvatar;
       await serverDB
         .update(users)
         .set({
-          avatar: userInfo.avatar || userInfo.permanentAvatar,
+          ...(isValidAvatar(casdoorAvatar) && { avatar: casdoorAvatar }),
           emailVerified: userInfo.email_verified ?? false,
           fullName: displayName,
           updatedAt: now,

--- a/src/app/(backend)/api/auth/casdoor/signup/route.ts
+++ b/src/app/(backend)/api/auth/casdoor/signup/route.ts
@@ -8,6 +8,7 @@ import { CasdoorClient } from '@/server/modules/Casdoor';
 import { createSignedSessionCookie } from '@/server/modules/Casdoor/cookie';
 import type { CasdoorSignupRequest, CasdoorSignupResponse } from '@/server/modules/Casdoor/types';
 import { UserService } from '@/server/services/user';
+import { generateDefaultAvatar, isValidAvatar } from '@/server/utils/avatar';
 
 // Session configuration
 const SESSION_EXPIRES_IN_DAYS = 7;
@@ -193,8 +194,12 @@ export async function POST(req: NextRequest) {
     const now = new Date();
     const userId = idGenerator('user', 32 - 'user_'.length);
 
+    // Use Casdoor avatar if available, otherwise generate a default one
+    const casdoorAvatar = userInfo.avatar || userInfo.permanentAvatar;
+    const avatar = isValidAvatar(casdoorAvatar) ? casdoorAvatar : generateDefaultAvatar(userId);
+
     await serverDB.insert(users).values({
-      avatar: userInfo.avatar || userInfo.permanentAvatar,
+      avatar,
       createdAt: now,
       email: normalizedEmail,
       emailVerified: userInfo.email_verified ?? false,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,6 +6,7 @@ import { emailHarmony } from 'better-auth-harmony';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { betterAuth } from 'better-auth/minimal';
 import { admin, emailOTP, genericOAuth, magicLink } from 'better-auth/plugins';
+import { eq } from 'drizzle-orm';
 
 import { account, session, verification } from '@/database/schemas/betterAuth';
 import { users } from '@/database/schemas/user';
@@ -21,6 +22,7 @@ import { createSecondaryStorage, getTrustedOrigins } from '@/libs/better-auth/ut
 import { parseSSOProviders } from '@/libs/better-auth/utils/server';
 import { EmailService } from '@/server/services/email';
 import { UserService } from '@/server/services/user';
+import { generateDefaultAvatar, isValidAvatar } from '@/server/utils/avatar';
 
 // Email verification link expiration time (in seconds)
 // Default is 1 hour (3600 seconds) as per Better Auth documentation
@@ -141,6 +143,15 @@ export const auth = betterAuth({
     user: {
       create: {
         after: async (user) => {
+          // Assign default avatar if user doesn't have one
+          if (!isValidAvatar(user.image)) {
+            const defaultAvatar = generateDefaultAvatar(user.id);
+            await serverDB
+              .update(users)
+              .set({ avatar: defaultAvatar })
+              .where(eq(users.id, user.id));
+          }
+
           const userService = new UserService(serverDB);
           await userService.initUser({
             email: user.email,
@@ -226,29 +237,29 @@ export const auth = betterAuth({
     }),
     ...(genericOAuthProviders.length > 0
       ? [
-        genericOAuth({
-          config: genericOAuthProviders,
-        }),
-      ]
+          genericOAuth({
+            config: genericOAuthProviders,
+          }),
+        ]
       : []),
     ...(enableMagicLink
       ? [
-        magicLink({
-          expiresIn: MAGIC_LINK_EXPIRES_IN,
-          sendMagicLink: async ({ email, url }) => {
-            const template = getMagicLinkEmailTemplate({
-              expiresInSeconds: MAGIC_LINK_EXPIRES_IN,
-              url,
-            });
+          magicLink({
+            expiresIn: MAGIC_LINK_EXPIRES_IN,
+            sendMagicLink: async ({ email, url }) => {
+              const template = getMagicLinkEmailTemplate({
+                expiresInSeconds: MAGIC_LINK_EXPIRES_IN,
+                url,
+              });
 
-            const emailService = new EmailService();
-            await emailService.sendMail({
-              to: email,
-              ...template,
-            });
-          },
-        }),
-      ]
+              const emailService = new EmailService();
+              await emailService.sendMail({
+                to: email,
+                ...template,
+              });
+            },
+          }),
+        ]
       : []),
   ],
 });

--- a/src/server/utils/avatar.ts
+++ b/src/server/utils/avatar.ts
@@ -1,0 +1,69 @@
+/**
+ * Default avatar generation utilities
+ *
+ * Uses DiceBear API to generate tech-style avatars
+ * @see https://www.dicebear.com/
+ */
+
+// DiceBear avatar styles - tech-oriented options
+export type AvatarStyle = 'bottts' | 'identicon' | 'shapes' | 'thumbs' | 'initials';
+
+// Default style for user avatars (bottts = robot style, tech-friendly)
+const DEFAULT_AVATAR_STYLE: AvatarStyle = 'bottts';
+
+// DiceBear API base URL
+const DICEBEAR_API_BASE = 'https://api.dicebear.com/9.x';
+
+/**
+ * Generate a default avatar URL using DiceBear
+ *
+ * @param seed - Unique identifier for the avatar (e.g., user ID or email)
+ * @param style - Avatar style (default: 'bottts' for robot style)
+ * @param format - Image format (default: 'svg')
+ * @returns Avatar URL
+ *
+ * @example
+ * ```typescript
+ * // Generate avatar for a user
+ * const avatarUrl = generateDefaultAvatar('user_abc123');
+ * // Returns: https://api.dicebear.com/9.x/bottts/svg?seed=user_abc123
+ *
+ * // Generate with specific style
+ * const avatarUrl = generateDefaultAvatar('user@example.com', 'identicon');
+ * // Returns: https://api.dicebear.com/9.x/identicon/svg?seed=user@example.com
+ * ```
+ */
+export const generateDefaultAvatar = (
+  seed: string,
+  style: AvatarStyle = DEFAULT_AVATAR_STYLE,
+  format: 'svg' | 'png' = 'svg',
+): string => {
+  // Encode the seed to handle special characters
+  const encodedSeed = encodeURIComponent(seed);
+
+  return `${DICEBEAR_API_BASE}/${style}/${format}?seed=${encodedSeed}`;
+};
+
+/**
+ * Generate a random default avatar URL
+ * Uses current timestamp + random number as seed
+ *
+ * @param style - Avatar style (default: 'bottts')
+ * @returns Random avatar URL
+ */
+export const generateRandomAvatar = (style: AvatarStyle = DEFAULT_AVATAR_STYLE): string => {
+  const randomSeed = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  return generateDefaultAvatar(randomSeed, style);
+};
+
+/**
+ * Check if a string is a valid avatar URL (not empty and looks like a URL)
+ *
+ * @param avatar - Avatar string to check
+ * @returns true if avatar is a valid URL
+ */
+export const isValidAvatar = (avatar?: string | null): boolean => {
+  if (!avatar) return false;
+  // Check if it's a URL (http/https) or a relative path starting with /
+  return avatar.startsWith('http://') || avatar.startsWith('https://') || avatar.startsWith('/');
+};


### PR DESCRIPTION
## Summary

- 创建 `src/server/utils/avatar.ts` 头像生成工具，使用 DiceBear API 的 bottts 风格生成技术感机器人头像
- 在 BetterAuth 用户创建钩子中添加默认头像分配逻辑
- 在 Casdoor 注册/登录流程中，当 Casdoor 未提供头像时自动生成默认头像
- 对于已有用户，仅当 Casdoor 提供有效头像时才更新

Closes #10

## Test plan

- [ ] 通过邮箱注册新用户，验证是否自动分配了 DiceBear bottts 风格头像
- [ ] 通过 Casdoor 注册新用户（无头像），验证是否自动分配默认头像
- [ ] 通过 Casdoor 登录已有用户（无 Casdoor 头像），验证原有头像不被覆盖
- [ ] 通过 Casdoor 登录已有用户（有 Casdoor 头像），验证头像被更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)